### PR TITLE
[Fix] Fixed emoji parse bug on iOS

### DIFF
--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -104,9 +104,9 @@ export const PlaylistList = ({
                   }}
                 >
                   {emoji ? (
-                    <Text as="span" fontSize="15" mr="4" maxW="1rem">
+                    <Flex mr="4" maxW="1rem">
                       {emoji}
-                    </Text>
+                    </Flex>
                   ) : (
                     <Icon
                       mr="4"


### PR DESCRIPTION
Changed the component from Text to Flex coz "Text" component has an emoji parse bug on iOS.

I didn't know how to rebase and force-push, so I had to re-create the commit. sorry for my poor git skills. (Thanks uetchy for all the advice!)