### PR TITLE
Changing the default position of youtube vid from top bar to sidebar

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -23,7 +23,7 @@ const englishNamePrefs = ["en", "es", "fr", "id", "pt", "de", "ru", "it"];
 
 // DND State Management
 export const settingsStore: SettingsStore = {
-  selectedPosition: "hover-top",
+  selectedPosition: "hidden",
   setSelectedPosition: action((state, newloc) => {
     state.selectedPosition = newloc;
   }),

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -23,7 +23,7 @@ const englishNamePrefs = ["en", "es", "fr", "id", "pt", "de", "ru", "it"];
 
 // DND State Management
 export const settingsStore: SettingsStore = {
-  selectedPosition: "hidden",
+  selectedPosition: "sidebar",
   setSelectedPosition: action((state, newloc) => {
     state.selectedPosition = newloc;
   }),


### PR DESCRIPTION
I change the default youtube position from top bar to sidebar because it's quite infuriating for new users that just create their account and want to access their profile. 

tl-dr : The default top-bar youtube video blocked the user's tab option.