### PR TITLE
Fix infinite back when "/" is visited

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js' & source-map-explorer --gzip 'build/static/js/*.js'",
     "build": "react-scripts build",
-    "dev": "GENERATE_SOURCEMAP=false react-scripts start",
+    "dev": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
     "dev:local-api": "cross-env API_TARGET=local react-scripts start",
     "eject": "react-scripts eject",
     "prepare": "husky install",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -27,7 +27,7 @@ const Search = React.lazy(() => import("./pages/Search"));
 
 const RedirectToOrg = () => {
   const org = useStoreState((store) => store.org.currentOrg);
-  return <Navigate to={`/org/${org.name || "Hololive"}`} />;
+  return <Navigate to={`/org/${org.name || "Hololive"}`} replace />;
 };
 
 const routes: RouteObject[] = [


### PR DESCRIPTION
When redirecting from `/`, it might be good to replace the original visit to `/` in the navigation history. Without this, the browser's back button somewhat stops working after a visit to `/` (entering through Google, clicking "Return to Home" in the expanded player bar, etc) due to an infinite loop (org &rarr; `/` &rarr; org &rarr; `/` ...).