### PR TITLE
Add search button to channel pages

### DIFF
--- a/src/pages/Channel.tsx
+++ b/src/pages/Channel.tsx
@@ -10,7 +10,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import axios from "axios";
-import { FiList, FiShare2, FiTwitter, FiYoutube } from "react-icons/fi";
+import { FiList, FiShare2, FiTwitter, FiYoutube, FiSearch } from "react-icons/fi";
 import { useQuery } from "react-query";
 import { Link, Route, Routes, useParams } from "react-router-dom";
 import { ChannelCard } from "../components/channel/ChannelCard";
@@ -204,6 +204,35 @@ function ChannelSocialButtons({
   );
 }
 
+interface PlaylistButton {
+  label: string,
+  link: string,
+  icon: any,
+}
+
+function getPlaylistButtons({
+  channel,
+  buttons,
+}: {
+  channel: any,
+  buttons: PlaylistButton[],
+}) {
+  return (buttons.map( button =>
+      <Button
+      variant="ghost"
+      size="md"
+      colorScheme="n2"
+      leftIcon={<button.icon />}
+      as={Link}
+      to={button.link}
+      float="right"
+      textTransform="uppercase"
+      >
+        {button.label}
+      </Button>
+  ));
+}
+
 function ChannelContent({
   discovery,
   trending,
@@ -218,6 +247,10 @@ function ChannelContent({
   channel: any;
 }) {
   const { t } = useTranslation();
+  const ButtonData = [
+    {label: "See All Songs", link: "/channel/" + channel.id + "/songs", icon: FiList}, 
+    {label: "Search Songs", link: `/searchV2?mode=fuzzy&ch=["${channel.name}"]`, icon: FiSearch}
+  ];
   return (
     <>
       {trending && (
@@ -246,20 +279,7 @@ function ChannelContent({
                 showArtwork: true,
               }}
               limit={5}
-              appendRight={
-                <Button
-                  variant="ghost"
-                  size="md"
-                  colorScheme="n2"
-                  leftIcon={<FiList />}
-                  as={Link}
-                  to={"/channel/" + channel.id + "/songs"}
-                  float="right"
-                  textTransform="uppercase"
-                >
-                  {t("See All Songs")}
-                </Button>
-              }
+              appendRight={getPlaylistButtons({ channel: channel, buttons: ButtonData})}
             />
           </Box>
         </>


### PR DESCRIPTION
Currently, it's somewhat cumbersome to search for songs from specific channels. To temporarily mitigate this, I added a button to the channel page which will take the user to advanced search with the channel already filled in.
![image](https://user-images.githubusercontent.com/41271523/210434811-8f34b368-9965-44a6-9481-fd35177f3a7f.png)
(This also restructures the code to make it easy to add more buttons there, though perhaps it was overkill)
